### PR TITLE
Increment counter in foreach loop

### DIFF
--- a/PHP/git.php
+++ b/PHP/git.php
@@ -22,10 +22,11 @@ Attendees:
 <?php 
 	$count = 0;
 	foreach ($arrayOfNames as $name) {
-			if ($count++ > 0) {
+			if ($count > 0) {
 				echo ', ';
 			}
 			echo $name;
+			$count++;
 	}
 ?>
 </div>

--- a/PHP/git.php
+++ b/PHP/git.php
@@ -22,7 +22,7 @@ Attendees:
 <?php 
 	$count = 0;
 	foreach ($arrayOfNames as $name) {
-			if ($count > 0) {
+			if ($count++ > 0) {
 				echo ', ';
 			}
 			echo $name;


### PR DESCRIPTION
Fix bug where $count was not incremented. $count++ lets the comparison be evaluated first, then the variable is incremented.